### PR TITLE
Simplify & reduce gas consumption for toAddress

### DIFF
--- a/contracts/BytesLib.sol
+++ b/contracts/BytesLib.sol
@@ -299,7 +299,7 @@ library BytesLib {
         address tempAddress;
 
         assembly {
-            tempAddress := div(mload(add(add(_bytes, 0x20), _start)), 0x1000000000000000000000000)
+            tempAddress := mload(add(add(_bytes, 0x14), _start))
         }
 
         return tempAddress;


### PR DESCRIPTION
Make it consistent with other toXXX variants.

- Gas consumption is reduced by 30
- Simplified the implementation so that to be consistent with other toXXX functions