### PR TITLE
Add uint24 support for BytesLib

### DIFF
--- a/contracts/BytesLib.sol
+++ b/contracts/BytesLib.sol
@@ -326,6 +326,17 @@ library BytesLib {
 
         return tempUint;
     }
+    
+    function toUint24(bytes memory _bytes, uint256 _start) internal pure returns (uint24) {
+        require(_bytes.length >= _start + 3, "toUint24_outOfBounds");
+        uint16 tempUint;
+
+        assembly {
+            tempUint := mload(add(add(_bytes, 0x3), _start))
+        }
+
+        return tempUint;
+    }
 
     function toUint32(bytes memory _bytes, uint256 _start) internal pure returns (uint32) {
         require(_bytes.length >= _start + 4, "toUint32_outOfBounds");


### PR DESCRIPTION
It would be great to add support for uint24. I needed this when working on a protocol that packs 4 uint24s and an address for storage optimization (same size as one uint256)