### PR TITLE
Add equal_nonAligned byte array method

### DIFF
--- a/contracts/AssertBytes.sol
+++ b/contracts/AssertBytes.sol
@@ -87,6 +87,103 @@ library AssertBytes {
     }
 
     /*
+        Function: equal_nonAligned(bytes memory, bytes memory)
+
+        Assert that two tightly packed bytes arrays that are not aligned to 32 bytes are equal.
+
+        Params:
+            A (bytes) - The first bytes.
+            B (bytes) - The second bytes.
+            message (string) - A message that is sent if the assertion fails.
+
+        Returns:
+            result (bool) - The result.
+    */
+    
+
+    function _equal_nonAligned(bytes memory _preBytes, bytes memory _postBytes) internal pure returns (bool) {
+        bool success = true;
+
+        assembly {
+            let length := mload(_preBytes)
+
+            // if lengths don't match the arrays are not equal
+            switch eq(length, mload(_postBytes))
+            case 1 {
+                // cb is a circuit breaker in the for loop since there's
+                //  no said feature for inline assembly loops
+                // cb = 1 - don't breaker
+                // cb = 0 - break
+                let cb := 1
+
+                let endMinusWord := add(_preBytes, length)
+                let mc := add(_preBytes, 0x20)
+                let cc := add(_postBytes, 0x20)
+
+                for {
+                // the next line is the loop condition:
+                // while(uint256(mc < endWord) + cb == 2)
+                } eq(add(lt(mc, endMinusWord), cb), 2) {
+                    mc := add(mc, 0x20)
+                    cc := add(cc, 0x20)
+                } {
+                    // if any of these checks fails then arrays are not equal
+                    if iszero(eq(mload(mc), mload(cc))) {
+                        // unsuccess:
+                        success := 0
+                        cb := 0
+                    }
+                }
+
+                // Only if still successful
+                // For <1 word tail bytes
+                if gt(success, 0) {
+                    // Get the remainder of length/32
+                    // length % 32 = AND(length, 32 - 1)
+                    let numTailBytes := and(length, 0x1f)
+                    let mcRem := mload(mc)
+                    let ccRem := mload(cc)
+                    for {
+                        let i := 0
+                    // the next line is the loop condition:
+                    // while(uint256(i < numTailBytes) + cb == 2)
+                    } eq(add(lt(i, numTailBytes), cb), 2) {
+                        i := add(i, 1)
+                    } {
+                        if iszero(eq(byte(i, mcRem), byte(i, ccRem))) {
+                            // unsuccess:
+                            success := 0
+                            cb := 0
+                        }
+                    }
+                }
+            }
+            default {
+                // unsuccess:
+                success := 0
+            }
+        }
+
+        return success;
+    }
+
+    function equal_nonAligned(bytes memory _a, bytes memory _b, string memory message) internal returns (bool) {
+        bool returnBool = _equal_nonAligned(_a, _b);
+
+        _report(returnBool, message);
+
+        return returnBool;
+    }
+
+    function notEqual_nonAligned(bytes memory _a, bytes memory _b, string memory message) internal returns (bool) {
+        bool returnBool = _equal_nonAligned(_a, _b);
+
+        _report(!returnBool, message);
+
+        return !returnBool;
+    }
+
+    /*
         Function: equal(bytes storage, bytes memory)
 
         Assert that two tightly packed bytes arrays are equal.

--- a/contracts/BytesLib.sol
+++ b/contracts/BytesLib.sol
@@ -473,6 +473,8 @@ library BytesLib {
                 // Only if still successful
                 // For <1 word tail bytes
                 if gt(success, 0) {
+                    // Get the remainder of length/32
+                    // length % 32 = AND(length, 32 - 1)
                     let numTailBytes := and(length, 0x1f)
                     let mcRem := mload(mc)
                     let ccRem := mload(cc)

--- a/contracts/BytesLib.sol
+++ b/contracts/BytesLib.sol
@@ -436,6 +436,70 @@ library BytesLib {
         return success;
     }
 
+    function equal_nonAligned(bytes memory _preBytes, bytes memory _postBytes) internal pure returns (bool) {
+        bool success = true;
+
+        assembly {
+            let length := mload(_preBytes)
+
+            // if lengths don't match the arrays are not equal
+            switch eq(length, mload(_postBytes))
+            case 1 {
+                // cb is a circuit breaker in the for loop since there's
+                //  no said feature for inline assembly loops
+                // cb = 1 - don't breaker
+                // cb = 0 - break
+                let cb := 1
+
+                let endMinusWord := add(_preBytes, length)
+                let mc := add(_preBytes, 0x20)
+                let cc := add(_postBytes, 0x20)
+
+                for {
+                // the next line is the loop condition:
+                // while(uint256(mc < endWord) + cb == 2)
+                } eq(add(lt(mc, endMinusWord), cb), 2) {
+                    mc := add(mc, 0x20)
+                    cc := add(cc, 0x20)
+                } {
+                    // if any of these checks fails then arrays are not equal
+                    if iszero(eq(mload(mc), mload(cc))) {
+                        // unsuccess:
+                        success := 0
+                        cb := 0
+                    }
+                }
+
+                // Only if still successful
+                // For <1 word tail bytes
+                if gt(success, 0) {
+                    let numTailBytes := and(length, 0x1f)
+                    let mcRem := mload(mc)
+                    let ccRem := mload(cc)
+                    for {
+                        let i := 0
+                    // the next line is the loop condition:
+                    // while(uint256(i < numTailBytes) + cb == 2)
+                    } eq(add(lt(i, numTailBytes), cb), 2) {
+                        i := add(i, 1)
+                    } {
+                        if iszero(eq(byte(i, mcRem), byte(i, ccRem))) {
+                            // unsuccess:
+                            success := 0
+                            cb := 0
+                        }
+                    }
+                }
+            }
+            default {
+                // unsuccess:
+                success := 0
+            }
+        }
+
+        return success;
+    }
+
     function equalStorage(
         bytes storage _preBytes,
         bytes memory _postBytes

--- a/test/TestBytesLib1.sol
+++ b/test/TestBytesLib1.sol
@@ -482,6 +482,106 @@ contract TestBytesLib1 {
     }
 
     /**
+    * Equality Non-aligned Tests
+    */
+
+    function testEqualNonAligned4Bytes() public {
+        bytes memory memBytes1 = hex"f00dfeed";
+        bytes memory memBytes2 = hex"f00dfeed";
+        // We need to make sure that the bytes are not aligned to a 32 byte boundary
+        // so we need to use assembly to allocate the bytes in contiguous memory
+        // Solidity will not let us do this normally, this equality method exists
+        // to test the edge case of non-aligned bytes created in assembly
+        assembly {
+            // What we'll do is we'll move the second array's pointer closer to the 
+            // end of the first array, such that the first byte of the second
+            // array is contiguous to the last byte of the first array
+            // first we copy its contents to a temporary variable
+            let temp := mload(memBytes2)
+            // 5 is the length of the first array plus one, for the length byte
+            memBytes2 := add(memBytes1, 5)
+            mstore(memBytes2, temp)
+            // now, just for completeness sake we'll update the free-memory pointer accordingly
+            mstore(0x40, add(memBytes2, 5))
+        }
+
+        AssertBytes.equal_nonAligned(memBytes1, memBytes2, "The equality check for the non-aligned equality 4-bytes-long test failed.");
+    }
+
+    function testEqualNonAligned4BytesFail() public {
+        bytes memory memBytes1 = hex"f00dfeed";
+        bytes memory memBytes2 = hex"feedf00d";
+        // We need to make sure that the bytes are not aligned to a 32 byte boundary
+        // so we need to use assembly to allocate the bytes in contiguous memory
+        // Solidity will not let us do this normally, this equality method exists
+        // to test the edge case of non-aligned bytes created in assembly
+        assembly {
+            // What we'll do is we'll move the second array's pointer closer to the 
+            // end of the first array, such that the first byte of the second
+            // array is contiguous to the last byte of the first array
+            // first we copy its contents to a temporary variable
+            let temp := mload(memBytes2)
+            // 5 is the length of the first array plus one, for the length byte
+            memBytes2 := add(memBytes1, 5)
+            mstore(memBytes2, temp)
+            // now, just for completeness sake we'll update the free-memory pointer accordingly
+            mstore(0x40, add(memBytes2, 5))
+        }
+
+        AssertBytes.notEqual_nonAligned(memBytes1, memBytes2, "The non equality check for the non-aligned equality 4-bytes-long test failed.");
+    }
+
+    function testEqualNonAligned33Bytes() public {
+        bytes memory memBytes1 = hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        bytes memory memBytes2 = hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        // We need to make sure that the bytes are not aligned to a 32 byte boundary
+        // so we need to use assembly to allocate the bytes in contiguous memory
+        // Solidity will not let us do this normally, this equality method exists
+        // to test the edge case of non-aligned bytes created in assembly
+        assembly {
+            // What we'll do is we'll move the second array's pointer closer to the 
+            // end of the first array, such that the first byte of the second
+            // array is contiguous to the last byte of the first array
+            // first we copy its contents to a temporary variable
+            let temp1 := mload(memBytes2)
+            let temp2 := mload(add(memBytes2, 0x20))
+            // 34 (0x22) is the length of the first array plus one, for the length byte
+            memBytes2 := add(memBytes1, 0x22)
+            mstore(memBytes2, temp1)
+            mstore(add(memBytes2, 0x20), temp2)
+            // now, just for completeness sake we'll update the free-memory pointer accordingly
+            mstore(0x40, add(memBytes2, 0x22))
+        }
+
+        AssertBytes.equal_nonAligned(memBytes1, memBytes2, "The equality check for the non-aligned equality 33-bytes-long test failed.");
+    }
+
+    function testEqualNonAligned33BytesFail() public {
+        bytes memory memBytes1 = hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        bytes memory memBytes2 = hex"f00d00000000000000000000000000000000000000000000000000000000feedee";
+        // We need to make sure that the bytes are not aligned to a 32 byte boundary
+        // so we need to use assembly to allocate the bytes in contiguous memory
+        // Solidity will not let us do this normally, this equality method exists
+        // to test the edge case of non-aligned bytes created in assembly
+        assembly {
+            // What we'll do is we'll move the second array's pointer closer to the 
+            // end of the first array, such that the first byte of the second
+            // array is contiguous to the last byte of the first array
+            // first we copy its contents to a temporary variable
+            let temp1 := mload(memBytes2)
+            let temp2 := mload(add(memBytes2, 0x20))
+            // 34 (0x22) is the length of the first array plus one, for the length byte
+            memBytes2 := add(memBytes1, 0x22)
+            mstore(memBytes2, temp1)
+            mstore(add(memBytes2, 0x20), temp2)
+            // now, just for completeness sake we'll update the free-memory pointer accordingly
+            mstore(0x40, add(memBytes2, 0x22))
+        }
+
+        AssertBytes.notEqual_nonAligned(memBytes1, memBytes2, "The non equality check for the non-aligned equality 33-bytes-long test failed.");
+    }
+
+    /**
     * Edge Cases
     */
 

--- a/test/TestBytesLib1.sol
+++ b/test/TestBytesLib1.sol
@@ -486,96 +486,196 @@ contract TestBytesLib1 {
     */
 
     function testEqualNonAligned4Bytes() public {
-        bytes memory memBytes1 = hex"f00dfeed";
-        bytes memory memBytes2 = hex"f00dfeed";
+        bytes memory memBytes1; // hex"f00dfeed"
+        bytes memory memBytes2; // hex"f00dfeed"
+
         // We need to make sure that the bytes are not aligned to a 32 byte boundary
         // so we need to use assembly to allocate the bytes in contiguous memory
         // Solidity will not let us do this normally, this equality method exists
         // to test the edge case of non-aligned bytes created in assembly
         assembly {
-            // What we'll do is we'll move the second array's pointer closer to the 
-            // end of the first array, such that the first byte of the second
-            // array is contiguous to the last byte of the first array
-            // first we copy its contents to a temporary variable
-            let temp := mload(memBytes2)
-            // 5 is the length of the first array plus one, for the length byte
-            memBytes2 := add(memBytes1, 5)
-            mstore(memBytes2, temp)
+            // Fetch free memory pointer
+            let freePointer := mload(0x40)
+
+            // We first store the length of the byte array (4 bytes)
+            // And then we write a byte at a time
+            memBytes1 := freePointer
+            mstore(freePointer, 0x04)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xf0)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0x0d)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xfe)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xed)
+            freePointer := add(freePointer, 0x1)
+
+            // We do the same for memBytes2 in contiguous memory
+            memBytes2 := freePointer
+            mstore(freePointer, 0x04)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xf0)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0x0d)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xfe)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xed)
+            freePointer := add(freePointer, 0x1)
+
+            // We add some garbage bytes in contiguous memory
+            mstore8(freePointer, 0xde)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xad)
+            freePointer := add(freePointer, 0x1)
+
             // now, just for completeness sake we'll update the free-memory pointer accordingly
-            mstore(0x40, add(memBytes2, 5))
+            mstore(0x40, freePointer)
         }
 
         AssertBytes.equal_nonAligned(memBytes1, memBytes2, "The equality check for the non-aligned equality 4-bytes-long test failed.");
+        // The equality check for aligned byte arrays should fail for non-aligned bytes
+        AssertBytes.notEqual(memBytes1, memBytes2, "The equality check for the non-aligned equality 4-bytes-long test failed.");
     }
 
     function testEqualNonAligned4BytesFail() public {
-        bytes memory memBytes1 = hex"f00dfeed";
-        bytes memory memBytes2 = hex"feedf00d";
+        bytes memory memBytes1; // hex"f00dfeed"
+        bytes memory memBytes2; // hex"feedf00d"
+
         // We need to make sure that the bytes are not aligned to a 32 byte boundary
         // so we need to use assembly to allocate the bytes in contiguous memory
         // Solidity will not let us do this normally, this equality method exists
         // to test the edge case of non-aligned bytes created in assembly
         assembly {
-            // What we'll do is we'll move the second array's pointer closer to the 
-            // end of the first array, such that the first byte of the second
-            // array is contiguous to the last byte of the first array
-            // first we copy its contents to a temporary variable
-            let temp := mload(memBytes2)
-            // 5 is the length of the first array plus one, for the length byte
-            memBytes2 := add(memBytes1, 5)
-            mstore(memBytes2, temp)
+            // Fetch free memory pointer
+            let freePointer := mload(0x40)
+
+            // We first store the length of the byte array (4 bytes)
+            // And then we write a byte at a time
+            memBytes1 := freePointer
+            mstore(freePointer, 0x04)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xf0)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0x0d)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xfe)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xed)
+            freePointer := add(freePointer, 0x1)
+
+            // We do the same for memBytes2 in contiguous memory
+            memBytes2 := freePointer
+            mstore(freePointer, 0x04)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xfe)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xed)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xf0)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0x0d)
+            freePointer := add(freePointer, 0x1)
+
+            // We add some garbage bytes in contiguous memory
+            mstore8(freePointer, 0xde)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xad)
+            freePointer := add(freePointer, 0x1)
+
             // now, just for completeness sake we'll update the free-memory pointer accordingly
-            mstore(0x40, add(memBytes2, 5))
+            mstore(0x40, freePointer)
         }
 
         AssertBytes.notEqual_nonAligned(memBytes1, memBytes2, "The non equality check for the non-aligned equality 4-bytes-long test failed.");
     }
 
     function testEqualNonAligned33Bytes() public {
-        bytes memory memBytes1 = hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
-        bytes memory memBytes2 = hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        bytes memory memBytes1; // hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        bytes memory memBytes2; // hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        
         // We need to make sure that the bytes are not aligned to a 32 byte boundary
         // so we need to use assembly to allocate the bytes in contiguous memory
         // Solidity will not let us do this normally, this equality method exists
         // to test the edge case of non-aligned bytes created in assembly
         assembly {
-            // What we'll do is we'll move the second array's pointer closer to the 
-            // end of the first array, such that the first byte of the second
-            // array is contiguous to the last byte of the first array
-            // first we copy its contents to a temporary variable
-            let temp1 := mload(memBytes2)
-            let temp2 := mload(add(memBytes2, 0x20))
-            // 34 (0x22) is the length of the first array plus one, for the length byte
-            memBytes2 := add(memBytes1, 0x22)
-            mstore(memBytes2, temp1)
-            mstore(add(memBytes2, 0x20), temp2)
+            // Fetch free memory pointer
+            let freePointer := mload(0x40)
+
+            // We first store the length of the byte array (33 bytes)
+            // And then we write a word and then a byte
+            memBytes1 := freePointer
+            mstore(freePointer, 0x21)
+            freePointer := add(freePointer, 0x20)
+            mstore(freePointer, 0xf00d00000000000000000000000000000000000000000000000000000000feed)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xcc)
+            freePointer := add(freePointer, 0x1)
+
+            // We do the same for memBytes2 in contiguous memory
+            memBytes2 := freePointer
+            mstore(freePointer, 0x21)
+            freePointer := add(freePointer, 0x20)
+            mstore(freePointer, 0xf00d00000000000000000000000000000000000000000000000000000000feed)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xcc)
+            freePointer := add(freePointer, 0x1)
+
+            // We add some garbage bytes in contiguous memory
+            mstore8(freePointer, 0xde)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xad)
+            freePointer := add(freePointer, 0x1)
+
             // now, just for completeness sake we'll update the free-memory pointer accordingly
-            mstore(0x40, add(memBytes2, 0x22))
+            mstore(0x40, freePointer)
         }
 
         AssertBytes.equal_nonAligned(memBytes1, memBytes2, "The equality check for the non-aligned equality 33-bytes-long test failed.");
+        // The equality check for aligned byte arrays should fail for non-aligned bytes
+        AssertBytes.notEqual(memBytes1, memBytes2, "The equality check for the non-aligned equality 4-bytes-long test failed.");
     }
 
     function testEqualNonAligned33BytesFail() public {
-        bytes memory memBytes1 = hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
-        bytes memory memBytes2 = hex"f00d00000000000000000000000000000000000000000000000000000000feedee";
+        bytes memory memBytes1; // hex"f00d00000000000000000000000000000000000000000000000000000000feedcc";
+        bytes memory memBytes2; // hex"f00d00000000000000000000000000000000000000000000000000000000feedee";
+        
         // We need to make sure that the bytes are not aligned to a 32 byte boundary
         // so we need to use assembly to allocate the bytes in contiguous memory
         // Solidity will not let us do this normally, this equality method exists
         // to test the edge case of non-aligned bytes created in assembly
         assembly {
-            // What we'll do is we'll move the second array's pointer closer to the 
-            // end of the first array, such that the first byte of the second
-            // array is contiguous to the last byte of the first array
-            // first we copy its contents to a temporary variable
-            let temp1 := mload(memBytes2)
-            let temp2 := mload(add(memBytes2, 0x20))
-            // 34 (0x22) is the length of the first array plus one, for the length byte
-            memBytes2 := add(memBytes1, 0x22)
-            mstore(memBytes2, temp1)
-            mstore(add(memBytes2, 0x20), temp2)
+            // Fetch free memory pointer
+            let freePointer := mload(0x40)
+
+            // We first store the length of the byte array (33 bytes)
+            // And then we write a word and then a byte
+            memBytes1 := freePointer
+            mstore(freePointer, 0x21)
+            freePointer := add(freePointer, 0x20)
+            mstore(freePointer, 0xf00d00000000000000000000000000000000000000000000000000000000feed)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xcc)
+            freePointer := add(freePointer, 0x1)
+
+            // We do the same for memBytes2 in contiguous memory
+            memBytes2 := freePointer
+            mstore(freePointer, 0x21)
+            freePointer := add(freePointer, 0x20)
+            mstore(freePointer, 0xf00d00000000000000000000000000000000000000000000000000000000feed)
+            freePointer := add(freePointer, 0x20)
+            mstore8(freePointer, 0xee)
+            freePointer := add(freePointer, 0x1)
+
+            // We add some garbage bytes in contiguous memory
+            mstore8(freePointer, 0xde)
+            freePointer := add(freePointer, 0x1)
+            mstore8(freePointer, 0xad)
+            freePointer := add(freePointer, 0x1)
+
             // now, just for completeness sake we'll update the free-memory pointer accordingly
-            mstore(0x40, add(memBytes2, 0x22))
+            mstore(0x40, freePointer)
         }
 
         AssertBytes.notEqual_nonAligned(memBytes1, memBytes2, "The non equality check for the non-aligned equality 33-bytes-long test failed.");


### PR DESCRIPTION
This change fixes the byte array equality check. The previous implementation did not account for non-zero adjacent memory when input byte arrays aren't a multiple of 32 bytes (1 word). As a result it was therefore possible for the equality check of two identical byte arrays to return false.

This PR updates the existing logic to only compare full words of byte arrays. The first for loop only runs until the last non-complete word. There is now another for loop that compares single bytes at a time until we reach the end of the byte array. 

The change to the existing loop is slightly cryptic since `endWord` adds the length of the byte array to the initial pointer rather than after moving the pointer forward by 32 bytes first (to account for the length of the byte array). The reasoning for this is that we save gas by not having to subtract 32 bytes from `endWord` every iteration of the first for loop.