### PR TITLE
Wrap slice overflow in unchecked block

### DIFF
--- a/contracts/BytesLib.sol
+++ b/contracts/BytesLib.sol
@@ -234,7 +234,11 @@ library BytesLib {
         pure
         returns (bytes memory)
     {
-        require(_length + 31 >= _length, "slice_overflow");
+        // We're using the unchecked block below because otherwise execution ends 
+        // with the native overflow error code.
+        unchecked {
+            require(_length + 31 >= _length, "slice_overflow");
+        }
         require(_bytes.length >= _start + _length, "slice_outOfBounds");
 
         bytes memory tempBytes;


### PR DESCRIPTION
This PR wraps the overflow check for the length of the bytes array int he slice method in an unchecked block in order to have the function revert with the intended message rather than the generic EVM overflow error code.